### PR TITLE
Initialization problem fixed

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -168,7 +168,11 @@ int main(void)
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
 	while (1) {
-		slCanCheckCommand(command);
+	    if(slCanProcessBuffer())
+	    {
+		    slCanCheckCommand(command);
+	    }
+	    
 		if (canRxFlags.flags.byte != 0) {
 			slcanReciveCanFrame(hcan.pRxMsg);
 			canRxFlags.flags.fifo1 = 0;
@@ -349,7 +353,7 @@ void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan) {
 }
 
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef * huart) {
-	slCanProccesInput(Uart2RxFifo);
+	slCanBufferInput(Uart2RxFifo);
 	__HAL_UART_FLUSH_DRREGISTER(huart);
 	HAL_UART_Receive_IT(huart, &Uart2RxFifo, UART_RX_FIFO_SIZE);
 }

--- a/Src/slcan/slcan.h
+++ b/Src/slcan/slcan.h
@@ -14,7 +14,7 @@
 
 
 #define VERSION_FIRMWARE_MAJOR 3
-#define VERSION_FIRMWARE_MINOR 2
+#define VERSION_FIRMWARE_MINOR 3
 
 #define VERSION_HARDWARE_MAJOR 1
 #define VERSION_HARDWARE_MINOR 1
@@ -30,11 +30,13 @@
 #define CAN_BR_1M 8
 #define CAN_BR_83K 36
 
-#define LINE_MAXLEN 100
+#define BUFFER_SIZE 128
+#define LINE_MAXLEN 64
 
 void slcanClose();
 uint8_t slcanReciveCanFrame(CanRxMsgTypeDef *pRxMsg);
-int slCanProccesInput(uint8_t ch);
+void slCanBufferInput(uint8_t ch);
+uint8_t slCanProcessBuffer();
 void slCanCheckCommand(uint8_t *line);
 
 extern uint8_t command[LINE_MAXLEN];

--- a/Src/usbd_cdc_if.c
+++ b/Src/usbd_cdc_if.c
@@ -285,18 +285,18 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
   */
 static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
-  /* USER CODE BEGIN 6 */
- uint32_t i;
- for (i =0; i != *Len; i++)
- {
-	 slCanProccesInput(Buf[i]);
- }
+    /* USER CODE BEGIN 6 */
+    uint32_t i;
+    for (i =0; i != *Len; i++)
+    {
+        slCanBufferInput(Buf[i]);
+    }
 
- USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
- USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
+    USBD_CDC_ReceivePacket(&hUsbDeviceFS);
 
- return (USBD_OK);
-  /* USER CODE END 6 */
+    return (USBD_OK);
+    /* USER CODE END 6 */
 }
 
 /**


### PR DESCRIPTION
If multiple commands were sent with a single USB packet only the last
command was accepted. Previous commands were ignored.

I only tested the firmware with the Java viewer and slcand. Both are working. I haven't tested the serial port available on the device itself.